### PR TITLE
fix(type): year 30xx to 20xx

### DIFF
--- a/reports/main.js
+++ b/reports/main.js
@@ -1,5 +1,5 @@
 const loadedData = {};	// Data loaded from files
-const monthsPretty = ["March 3025", "April 3025", "May 3025", "June 3025", "July 3025"];
+const monthsPretty = ["March 2025", "April 2025", "May 2025", "June 2025", "July 2025"];
 const months = ["mar25", "apr25", "may25", "jun25", "jul25"];
 const currentMonth = "jul25";
 	


### PR DESCRIPTION
Fixes the labels in the year selector from **30**xx to **20**xx.

<img width="292" height="189" alt="Screenshot 2025-08-14 at 14 02 47" src="https://github.com/user-attachments/assets/26d59587-8ce2-41d3-8ffc-48f3f8a72530" />
<img width="309" height="159" alt="Screenshot 2025-08-14 at 14 02 16" src="https://github.com/user-attachments/assets/4c7bc2c3-d884-4fed-bf24-7cec9d39406f" />
